### PR TITLE
Parse with miner u

### DIFF
--- a/backend/download_models_hf.py
+++ b/backend/download_models_hf.py
@@ -1,0 +1,74 @@
+import json
+import os
+import shutil
+
+import requests
+from huggingface_hub import snapshot_download
+
+
+def download_json(url):
+    # 下载JSON文件
+    response = requests.get(url)
+    response.raise_for_status()  # 检查请求是否成功
+    return response.json()
+
+
+def download_and_modify_json(url, local_filename, modifications):
+    if os.path.exists(local_filename):
+        data = json.load(open(local_filename))
+        config_version = data.get('config_version', '0.0.0')
+        if config_version < '1.2.0':
+            data = download_json(url)
+    else:
+        data = download_json(url)
+
+    # 修改内容
+    for key, value in modifications.items():
+        data[key] = value
+
+    # 保存修改后的内容
+    with open(local_filename, 'w', encoding='utf-8') as f:
+        json.dump(data, f, ensure_ascii=False, indent=4)
+
+
+if __name__ == '__main__':
+
+    mineru_patterns = [
+        # "models/Layout/LayoutLMv3/*",
+        "models/Layout/YOLO/*",
+        "models/MFD/YOLO/*",
+        "models/MFR/unimernet_hf_small_2503/*",
+        "models/OCR/paddleocr_torch/*",
+        # "models/TabRec/TableMaster/*",
+        # "models/TabRec/StructEqTable/*",
+    ]
+    model_dir = snapshot_download('opendatalab/PDF-Extract-Kit-1.0', allow_patterns=mineru_patterns)
+
+    layoutreader_pattern = [
+        "*.json",
+        "*.safetensors",
+    ]
+    layoutreader_model_dir = snapshot_download('hantian/layoutreader', allow_patterns=layoutreader_pattern)
+
+    model_dir = model_dir + '/models'
+    print(f'model_dir is: {model_dir}')
+    print(f'layoutreader_model_dir is: {layoutreader_model_dir}')
+
+    # paddleocr_model_dir = model_dir + '/OCR/paddleocr'
+    # user_paddleocr_dir = os.path.expanduser('~/.paddleocr')
+    # if os.path.exists(user_paddleocr_dir):
+    #     shutil.rmtree(user_paddleocr_dir)
+    # shutil.copytree(paddleocr_model_dir, user_paddleocr_dir)
+
+    json_url = 'https://github.com/opendatalab/MinerU/raw/master/magic-pdf.template.json'
+    config_file_name = 'magic-pdf.json'
+    home_dir = os.path.expanduser('~')
+    config_file = os.path.join(home_dir, config_file_name)
+
+    json_mods = {
+        'models-dir': model_dir,
+        'layoutreader-model-dir': layoutreader_model_dir,
+    }
+
+    download_and_modify_json(json_url, config_file, json_mods)
+    print(f'The configuration file has been configured successfully, the path is: {config_file}')

--- a/backend/services/parse_md_service.py
+++ b/backend/services/parse_md_service.py
@@ -1,0 +1,336 @@
+import logging
+import os
+from datetime import datetime
+from pathlib import Path
+from langchain_text_splitters import MarkdownHeaderTextSplitter, RecursiveCharacterTextSplitter
+
+logger = logging.getLogger(__name__)
+
+class ParseMDService:
+    def __init__(self):
+        self.logger = logging.getLogger(__name__)
+        
+    def parse_pdf_to_md(self, parsing_option, metadata):
+        """
+        Convert PDF content to Markdown format using MinerU API
+        
+        Args:
+            parsing_option (str): 'one' or 'by_headers'
+            metadata (dict): Metadata about the document, must include 'temp_path'
+            
+        Returns:
+            dict: Parsed content in markdown format
+        """
+        self.logger.info(f"Converting PDF to Markdown with option: {parsing_option}")
+        
+        if metadata is None:
+            metadata = {}
+        
+        # Get the path to the PDF file from metadata (from temp directory)
+        pdf_path = metadata.get("temp_path", "")
+        
+        if not pdf_path or not os.path.exists(pdf_path):
+            self.logger.error(f"PDF file not found: {pdf_path}")
+            raise FileNotFoundError(f"PDF file not found: {pdf_path}")
+        
+        # Create output directories
+        output_dir = os.path.join("05-markdown-docs")
+        image_dir = os.path.join(output_dir, "images")
+        os.makedirs(output_dir, exist_ok=True)
+        os.makedirs(image_dir, exist_ok=True)
+        
+        # Generate unique filename
+        filename = metadata.get("filename", "")
+        basename = os.path.basename(filename).split(".")[0]
+        timestamp = datetime.now().strftime("%Y%m%d%H%M%S")
+        output_md_file = f"{basename}_{timestamp}.md"
+        output_md_path = os.path.join(output_dir, output_md_file)
+        
+        # Use MinerU to convert PDF to Markdown
+        try:
+            # Read PDF file as bytes
+            with open(pdf_path, "rb") as f:
+                pdf_bytes = f.read()
+            
+            # Mode selection for MinerU API
+            ocr_mode = False  # Default
+            if parsing_option == "by_headers":
+                ocr_mode = True  # Use OCR mode for better header detection
+                
+            # Convert PDF to Markdown using MinerU API
+            self._convert_using_mineru_api(
+                pdf_bytes, 
+                output_dir, 
+                image_dir, 
+                basename, 
+                output_md_file,
+                ocr_mode
+            )
+                
+            # Read the generated markdown content
+            with open(output_md_path, 'r', encoding='utf-8') as f:
+                md_content = f.read()
+                
+            # Format the results for the frontend
+            result = {
+                "metadata": {
+                    "filename": metadata.get("filename", "unknown"),
+                    "parsing_method": parsing_option,
+                    "timestamp": datetime.now().isoformat(),
+                    "md_file_path": output_md_path
+                },
+                "content": []
+            }
+            
+            # Use LangChain's MarkdownHeaderTextSplitter for better header-based splitting
+            if parsing_option == "by_headers":
+                result["content"] = self._split_md_by_langchain(md_content, basename)
+            else:
+                # Return the entire document as a single markdown block
+                result["content"].append({
+                    "type": "markdown",
+                    "title": basename,
+                    "content": md_content
+                })
+                    
+            return result
+                
+        except Exception as e:
+            self.logger.error(f"Error using MinerU to convert PDF: {str(e)}")
+            self.logger.info("Falling back to alternative conversion...")
+            
+            # Try to use another external tool or method to convert the PDF
+            try:
+                import subprocess
+                
+                # Create temporary output file
+                temp_md_path = os.path.join(output_dir, f"temp_{basename}.md")
+                
+                # Try to use pandoc for conversion if available
+                result = subprocess.run(
+                    ["pandoc", pdf_path, "-o", temp_md_path], 
+                    capture_output=True, 
+                    text=True, 
+                    check=False
+                )
+                
+                if os.path.exists(temp_md_path):
+                    # Read the generated markdown content
+                    with open(temp_md_path, 'r', encoding='utf-8') as f:
+                        md_content = f.read()
+                    
+                    # Move to final filename
+                    os.rename(temp_md_path, output_md_path)
+                    
+                    # Format the results for the frontend
+                    result = {
+                        "metadata": {
+                            "filename": metadata.get("filename", "unknown"),
+                            "parsing_method": f"{parsing_option} (fallback)",
+                            "timestamp": datetime.now().isoformat(),
+                            "md_file_path": output_md_path
+                        },
+                        "content": []
+                    }
+                    
+                    if parsing_option == "by_headers":
+                        result["content"] = self._split_md_by_langchain(md_content, basename)
+                    else:
+                        # Return the entire document as a single markdown block
+                        result["content"].append({
+                            "type": "markdown",
+                            "title": basename,
+                            "content": md_content
+                        })
+                        
+                    return result
+                else:
+                    raise FileNotFoundError("Failed to generate markdown file")
+                    
+            except Exception as fallback_error:
+                self.logger.error(f"Error in fallback conversion: {str(fallback_error)}")
+                
+                # Create a minimal markdown file with an error message
+                with open(output_md_path, 'w', encoding='utf-8') as md_file:
+                    md_file.write(f"# Conversion Error\n\nFailed to convert {filename} to markdown.\n\n")
+                    md_file.write(f"Error: {str(e)}\n\n")
+                    md_file.write(f"Fallback error: {str(fallback_error)}\n")
+                
+                # Return minimal content
+                return {
+                    "metadata": {
+                        "filename": metadata.get("filename", "unknown"),
+                        "parsing_method": "error",
+                        "timestamp": datetime.now().isoformat(),
+                        "md_file_path": output_md_path,
+                        "error": str(e)
+                    },
+                    "content": [{
+                        "type": "markdown",
+                        "title": f"Error converting {basename}",
+                        "content": f"# Conversion Error\n\nFailed to convert {filename} to markdown.\n\n" +
+                                   f"Error: {str(e)}\n\n" +
+                                   f"Fallback error: {str(fallback_error)}\n"
+                    }]
+                }
+    
+    def _convert_using_mineru_api(self, pdf_bytes, output_dir, image_dir, basename, output_md_file, ocr_mode=False):
+        """
+        Use MinerU Python API to convert PDF to Markdown
+        
+        Following the official MinerU documentation:
+        https://mineru.readthedocs.io/en/latest/user_guide/quick_start/convert_pdf.html
+        """
+        self.logger.info("Using MinerU Python API to convert PDF")
+        
+        try:
+            # Import MinerU modules
+            from magic_pdf.data.data_reader_writer import FileBasedDataWriter
+            from magic_pdf.data.dataset import PymuDocDataset
+            from magic_pdf.model.doc_analyze_by_custom_model import doc_analyze
+            
+            # Prepare environment
+            image_dir_basename = os.path.basename(image_dir)
+            
+            # Create writers
+            image_writer = FileBasedDataWriter(image_dir)
+            md_writer = FileBasedDataWriter(output_dir)
+            
+            # Create dataset instance
+            ds = PymuDocDataset(pdf_bytes)
+            
+            # Apply document analysis with specified OCR mode
+            ds = ds.apply(doc_analyze, ocr=ocr_mode)
+            
+            # Generate markdown based on the OCR mode
+            if ocr_mode:
+                # Use OCR mode
+                ds = ds.pipe_ocr_mode(image_writer)
+            else:
+                # Use text mode
+                ds = ds.pipe_txt_mode(image_writer)
+                
+            # Generate the markdown file
+            ds.dump_md(md_writer, output_md_file, image_dir_basename)
+            
+            self.logger.info(f"Successfully generated markdown file: {os.path.join(output_dir, output_md_file)}")
+            return True
+            
+        except ImportError as e:
+            self.logger.error(f"MinerU API import error: {str(e)}")
+            raise RuntimeError(f"MinerU API not available: {str(e)}")
+        except Exception as e:
+            self.logger.error(f"MinerU API error: {str(e)}")
+            raise RuntimeError(f"MinerU API conversion failed: {str(e)}")
+    
+    def _split_md_by_langchain(self, md_content, title="Document"):
+        """
+        Split markdown content by headers using LangChain's MarkdownHeaderTextSplitter
+        Returns list of content dictionaries
+        """
+        self.logger.info("Splitting markdown content by headers using LangChain")
+        
+        # Define headers to split on (standard markdown headers)
+        headers_to_split_on = [
+            ("#", "Header 1"),
+            ("##", "Header 2"),
+            ("###", "Header 3"),
+            ("####", "Header 4"),
+            ("#####", "Header 5"),
+            ("######", "Header 6"),
+        ]
+        
+        try:
+            # Create the splitter
+            markdown_splitter = MarkdownHeaderTextSplitter(
+                headers_to_split_on=headers_to_split_on,
+                strip_headers=False  # Keep headers in content for better context
+            )
+            
+            # Split the markdown content
+            splits = markdown_splitter.split_text(md_content)
+            
+            # If the content doesn't have proper headers, fallback to regular text chunking
+            if not splits:
+                self.logger.warning("No headers found in markdown, using RecursiveCharacterTextSplitter")
+                text_splitter = RecursiveCharacterTextSplitter(
+                    chunk_size=2000,
+                    chunk_overlap=200
+                )
+                splits = text_splitter.create_documents([md_content])
+            
+            # Format for our API response
+            content_list = []
+            for i, doc in enumerate(splits):
+                # Determine the title from metadata or use a default
+                section_title = None
+                
+                # Check for header information in metadata
+                metadata = doc.metadata
+                if "Header 1" in metadata:
+                    section_title = metadata["Header 1"]
+                elif "Header 2" in metadata:
+                    section_title = metadata["Header 2"]
+                elif "Header 3" in metadata:
+                    section_title = metadata["Header 3"]
+                
+                # If no title found, use a section number
+                if not section_title:
+                    section_title = f"Section {i+1}"
+                
+                content_list.append({
+                    "type": "markdown",
+                    "section": i + 1,
+                    "title": section_title,
+                    "content": doc.page_content,
+                    "metadata": metadata
+                })
+            
+            return content_list
+            
+        except Exception as e:
+            self.logger.error(f"Error splitting markdown with LangChain: {str(e)}")
+            # Fallback to basic splitting method
+            sections = self._split_md_by_headers(md_content)
+            content_list = []
+            for i, (header, content) in enumerate(sections):
+                content_list.append({
+                    "type": "markdown",
+                    "section": i + 1,
+                    "title": header or title,
+                    "content": content
+                })
+            return content_list
+    
+    def _split_md_by_headers(self, md_content):
+        """
+        Split markdown content by headers
+        Returns list of tuples (header, content)
+        """
+        lines = md_content.split('\n')
+        sections = []
+        
+        current_header = "Document"
+        current_content = []
+        
+        for line in lines:
+            if line.startswith('#'):
+                # Found a header
+                if current_content:
+                    sections.append((current_header, '\n'.join(current_content)))
+                    current_content = []
+                
+                # Remove the # markers and use as the header
+                current_header = line.lstrip('#').strip()
+            else:
+                current_content.append(line)
+        
+        # Add the last section
+        if current_content:
+            sections.append((current_header, '\n'.join(current_content)))
+        
+        # If no headers were found, treat the entire document as one section
+        if not sections and md_content:
+            sections.append(("Document", md_content))
+            
+        return sections 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,7 +12,11 @@
   "dependencies": {
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "react-router-dom": "^7.0.1"
+    "react-router-dom": "^7.0.1",
+    "react-markdown": "^10.1.0",
+    "rehype-highlight": "^7.0.2",
+    "rehype-raw": "^7.0.0",
+    "remark-gfm": "^4.0.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.13.0",

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -8,6 +8,7 @@ import EmbeddingFile from './pages/EmbeddingFile';
 import Indexing from './pages/Indexing';
 import Search from './pages/Search';
 import ParseFile from './pages/ParseFile';
+import ParseMDFile from './pages/ParseMDFile';
 import Generation from './pages/Generation';
 
 const App = () => {
@@ -20,6 +21,7 @@ const App = () => {
             <Route path="/load-file" element={<LoadFile />} />  
             <Route path="/chunk-file" element={<ChunkFile />} />  
             <Route path="/parse-file" element={<ParseFile />} />
+            <Route path="/parse-md-file" element={<ParseMDFile />} />
             <Route path="/embedding" element={<EmbeddingFile />} />
             <Route path="/indexing" element={<Indexing />} />
             <Route path="/search" element={<Search />} />

--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -8,6 +8,7 @@ const Sidebar = () => {
     { to: "/load-file", text: "Load File" },
     { to: "/chunk-file", text: "Chunk File" },
     { to: "/parse-file", text: "Parse File" },
+    { to: "/parse-md-file", text: "PDF to Markdown" },
     { to: "/embedding", text: "Embedding File" },
     { to: "/indexing", text: "Indexing with Vector DB" },
     { to: "/search", text: "Similarity Search" },

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -2,6 +2,87 @@
 @tailwind components;
 @tailwind utilities;
 
+/* Add the code highlighting styles for rehype-highlight */
+@import url('https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/github.min.css');
+
+/* Markdown content styling */
+.markdown-content {
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+  line-height: 1.6;
+  color: #333;
+}
+
+.markdown-content h1, 
+.markdown-content h2, 
+.markdown-content h3, 
+.markdown-content h4, 
+.markdown-content h5, 
+.markdown-content h6 {
+  margin-top: 1em;
+  margin-bottom: 0.5em;
+  font-weight: 600;
+}
+
+.markdown-content h1 { font-size: 1.75em; }
+.markdown-content h2 { font-size: 1.5em; }
+.markdown-content h3 { font-size: 1.25em; }
+.markdown-content p { margin-bottom: 1em; }
+.markdown-content a { color: #0366d6; text-decoration: none; }
+.markdown-content a:hover { text-decoration: underline; }
+
+.markdown-content code {
+  font-family: SFMono-Regular, Consolas, 'Liberation Mono', Menlo, monospace;
+  background-color: rgba(27, 31, 35, 0.05);
+  padding: 0.2em 0.4em;
+  border-radius: 3px;
+  font-size: 85%;
+}
+
+.markdown-content pre {
+  background-color: #f6f8fa;
+  border-radius: 3px;
+  padding: 1em;
+  overflow: auto;
+}
+
+.markdown-content blockquote {
+  border-left: 0.25em solid #dfe2e5;
+  padding-left: 1em;
+  margin-left: 0;
+  color: #6a737d;
+}
+
+.markdown-content ul, 
+.markdown-content ol {
+  padding-left: 2em;
+  margin-bottom: 1em;
+}
+
+.markdown-content li { 
+  margin-bottom: 0.25em; 
+}
+
+.markdown-content table {
+  border-collapse: collapse;
+  width: 100%;
+  margin-bottom: 1em;
+}
+
+.markdown-content table th, 
+.markdown-content table td {
+  padding: 6px 13px;
+  border: 1px solid #dfe2e5;
+}
+
+.markdown-content table th {
+  background-color: #f6f8fa;
+}
+
+.markdown-content img {
+  max-width: 100%;
+  box-sizing: content-box;
+}
+
 :root {
   font-family: Inter, system-ui, Avenir, Helvetica, Arial, sans-serif;
   line-height: 1.5;

--- a/frontend/src/pages/ParseMDFile.jsx
+++ b/frontend/src/pages/ParseMDFile.jsx
@@ -1,0 +1,202 @@
+import React, { useState } from 'react';
+import ReactMarkdown from 'react-markdown';
+import rehypeRaw from 'rehype-raw';
+import rehypeHighlight from 'rehype-highlight';
+import remarkGfm from 'remark-gfm';
+import RandomImage from '../components/RandomImage';
+import { apiBaseUrl } from '../config/config';
+
+const ParseMDFile = () => {
+  const [file, setFile] = useState(null);
+  const [loadingMethod, setLoadingMethod] = useState('mineru');
+  const [parsingOption, setParsingOption] = useState('one');
+  const [parsedContent, setParsedContent] = useState(null);
+  const [status, setStatus] = useState('');
+  const [docName, setDocName] = useState('');
+  const [isProcessed, setIsProcessed] = useState(false);
+  const [viewMode, setViewMode] = useState('rendered'); // 'rendered' or 'raw'
+
+  const handleProcess = async () => {
+    if (!file || !loadingMethod || !parsingOption) {
+      setStatus('Please select all required options');
+      return;
+    }
+
+    setStatus('Processing...');
+    setParsedContent(null);
+    setIsProcessed(false);
+
+    try {
+      const formData = new FormData();
+      formData.append('file', file);
+      formData.append('loading_method', loadingMethod);
+      formData.append('parsing_option', parsingOption);
+
+      const response = await fetch(`${apiBaseUrl}/parse_md`, {
+        method: 'POST',
+        body: formData
+      });
+
+      if (!response.ok) {
+        throw new Error(`HTTP error! status: ${response.status}`);
+      }
+
+      const data = await response.json();
+      setParsedContent(data.parsed_content);
+      setStatus('Processing completed successfully!');
+      setIsProcessed(true);
+    } catch (error) {
+      console.error('Error:', error);
+      setStatus(`Error: ${error.message}`);
+    }
+  };
+
+  const handleFileSelect = (e) => {
+    const file = e.target.files[0];
+    if (file) {
+      setFile(file);
+      const baseName = file.name.replace('.pdf', '');
+      setDocName(baseName);
+    }
+  };
+
+  const toggleViewMode = () => {
+    setViewMode(viewMode === 'rendered' ? 'raw' : 'rendered');
+  };
+
+  // Component to render markdown content
+  const MarkdownContent = ({ content }) => {
+    if (viewMode === 'rendered') {
+      return (
+        <div className="markdown-content">
+          <ReactMarkdown
+            rehypePlugins={[rehypeRaw, rehypeHighlight]}
+            remarkPlugins={[remarkGfm]}
+          >
+            {content}
+          </ReactMarkdown>
+        </div>
+      );
+    } else {
+      return (
+        <pre className="bg-gray-100 p-3 rounded font-mono text-sm overflow-auto whitespace-pre-wrap">
+          {content}
+        </pre>
+      );
+    }
+  };
+
+  return (
+    <div className="p-6">
+      <h2 className="text-2xl font-bold mb-6">Parse PDF to Markdown</h2>
+      
+      <div className="grid grid-cols-12 gap-6">
+        {/* Left Panel (3/12) */}
+        <div className="col-span-3 space-y-4">
+          <div className="p-4 border rounded-lg bg-white shadow-sm">
+            <div>
+              <label className="block text-sm font-medium mb-1">Upload PDF File</label>
+              <input
+                type="file"
+                accept=".pdf"
+                onChange={handleFileSelect}
+                className="block w-full border rounded px-3 py-2"
+                required
+              />
+            </div>
+
+            <div className="mt-4">
+              <label className="block text-sm font-medium mb-1">Loading Tool</label>
+              <select
+                value={loadingMethod}
+                onChange={(e) => setLoadingMethod(e.target.value)}
+                className="block w-full p-2 border rounded"
+              >
+                <option value="mineru">MinerU</option>
+              </select>
+            </div>
+
+            <div className="mt-4">
+              <label className="block text-sm font-medium mb-1">Parsing Option</label>
+              <select
+                value={parsingOption}
+                onChange={(e) => setParsingOption(e.target.value)}
+                className="block w-full p-2 border rounded"
+              >
+                <option value="one">One</option>
+                <option value="by_headers">By Headers</option>
+              </select>
+            </div>
+
+            <button 
+              onClick={handleProcess}
+              className="mt-4 w-full px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-600"
+              disabled={!file}
+            >
+              Convert to Markdown
+            </button>
+          </div>
+          
+          {status && (
+            <div className={`p-4 rounded-lg ${
+              status.includes('Error') ? 'bg-red-100 text-red-700' : 'bg-green-100 text-green-700'
+            }`}>
+              {status}
+            </div>
+          )}
+        </div>
+
+        {/* Right Panel (9/12) */}
+        <div className="col-span-9 border rounded-lg bg-white shadow-sm">
+          {parsedContent ? (
+            <div className="p-4">
+              <div className="flex justify-between items-center mb-4">
+                <h3 className="text-xl font-semibold">Markdown Results</h3>
+                <div className="flex items-center">
+                  <span className="mr-2 text-sm text-gray-600">View mode:</span>
+                  <button 
+                    onClick={toggleViewMode}
+                    className="px-3 py-1 bg-blue-100 text-blue-800 rounded hover:bg-blue-200"
+                  >
+                    {viewMode === 'rendered' ? 'Show Raw' : 'Show Rendered'}
+                  </button>
+                </div>
+              </div>
+              
+              <div className="mb-4 p-3 border rounded bg-gray-100">
+                <h4 className="font-medium mb-2">Document Information</h4>
+                <div className="text-sm text-gray-600">
+                  <p>Filename: {parsedContent.metadata?.filename}</p>
+                  <p>Parsing Method: {parsedContent.metadata?.parsing_method}</p>
+                  <p>Timestamp: {parsedContent.metadata?.timestamp && new Date(parsedContent.metadata.timestamp).toLocaleString()}</p>
+                </div>
+              </div>
+              
+              <div className="space-y-3 max-h-[calc(100vh-300px)] overflow-y-auto">
+                {parsedContent.content.map((item, idx) => (
+                  <div key={idx} className="p-3 border rounded bg-gray-50">
+                    <div className="font-medium text-sm text-gray-500 mb-1">
+                      {item.type} {item.section && `- Section ${item.section}`}
+                    </div>
+                    {item.title && (
+                      <div className="font-bold text-gray-700 mb-2">
+                        {item.title}
+                      </div>
+                    )}
+                    <div className={`${viewMode === 'raw' ? 'text-sm text-gray-600' : 'markdown-preview'}`}>
+                      <MarkdownContent content={item.content} />
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          ) : (
+            <RandomImage message="Upload a PDF file to convert to Markdown" />
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ParseMDFile; 


### PR DESCRIPTION
This PR add additional Page "Parse PDF to Markdown". It provides [MinerU](https://github.com/opendatalab/MinerU) as loading tool. First it will convert PDF into MD file. Then it will chunk the MD file into chunks. Now you can either chunk it into one piece(whole) or By Titles (Using langchain [MarkdownHeaderTextSplitter](https://python.langchain.com/docs/how_to/markdown_header_metadata_splitter/)). See one sample result in the following pic:
![image](https://github.com/user-attachments/assets/664f9b3c-ce82-4d89-818a-fb68e530c4ee)
